### PR TITLE
Add cargo-make integration

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,12 @@
+[config]
+default_to_workspace = false
+
+[env]
+RUST_BACKTRACE = "1"
+CARGO_MAKE_CLIPPY_ARGS = "${CARGO_MAKE_CLIPPY_ALL_FEATURES_WARN}"
+
+[tasks.lint]
+dependencies = [
+  "check-format",
+  "clippy",
+]


### PR DESCRIPTION
This adds a default _Makefile.toml_ for specifying custom _cargo-make_ tasks.