### PR TITLE
Add rusty-hook integration

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -10,3 +10,13 @@ dependencies = [
   "check-format",
   "clippy",
 ]
+
+[tasks.pre-git-commit]
+dependencies = [
+  "lint",
+]
+
+[tasks.pre-git-push]
+dependencies = [
+  "test",
+]

--- a/rusty-hook.toml
+++ b/rusty-hook.toml
@@ -1,0 +1,6 @@
+[hooks]
+pre-commit = "cargo make pre-git-commit"
+pre-push = "cargo make pre-git-push"
+
+[logging]
+verbose = false


### PR DESCRIPTION
This adds _rusty-hook_ integration to ensure that code is linted and tested before being committed/pushed and sent to the continuous integration pipeline.