### PR TITLE
Add continuous integration workflow path checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: build
 on:
   pull_request:
+    paths:
+    - '**.rs'
+    - '**/Cargo.toml'
+    - '**/Cargo.lock'
   push:
     branches:
     - master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,10 @@
 name: lint
-on: pull_request
+on:
+  pull_request:
+    paths:
+    - '**.rs'
+    - clippy.toml
+    - rustfmt.toml
 jobs:
   rustfmt:
     name: rustfmt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: test
 on:
   pull_request:
+    paths:
+    - '**.rs'
+    - '**/Cargo.toml'
+    - '**/Cargo.lock'
   push:
     branches:
     - master


### PR DESCRIPTION
This speeds up _GitHub Actions_ pull request workflows by only performing builds, lints and tests when the source files or other relevant metadata has changed. This will allow other files such as the _README_ to change without requiring a full build.