### PR TITLE
Add code coverage via grcov on codecov

### DIFF
--- a/.github/configs/codecov.yml
+++ b/.github/configs/codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/.github/configs/grcov.yml
+++ b/.github/configs/grcov.yml
@@ -1,0 +1,6 @@
+branch: true
+ignore-not-existing: true
+llvm: true
+output-type: lcov
+output-file: ./lcov.info
+prefix-dir: /home/user/build/

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,6 +20,17 @@ jobs:
       with:
         toolchain: nightly
         override: true
+    - name: Download grcov
+      run: |
+        LOCATION=$(curl -s https://api.github.com/repos/mozilla/grcov/releases/latest \
+        | grep "tag_name" \
+        | awk '{print "https://github.com/mozilla/grcov/releases/download/" substr($2, 2, length($2)-3) "/grcov-linux-x86_64.tar.bz2"}')
+        mkdir bin
+        curl -L -o grcov.tar.bz2 $LOCATION
+        tar xjf grcov.tar.bz2 -C "$PWD/bin"
+        echo "::add-path::$PWD/bin"
+        rm -f grcov.tar.bz2
+      shell: bash
     - uses: actions-rs/cargo@v1
       with:
         command: test

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,7 @@ on:
     - '**/Cargo.toml'
     - '**/Cargo.lock'
     - .github/workflows/coverage.yml
+    - .github/configs/grcov.yml
   push:
     branches:
     - master
@@ -28,6 +29,8 @@ jobs:
         RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads'
     - id: coverage
       uses: actions-rs/grcov@v0.1
+      with:
+        config: .github/configs/grcov.yml
     - uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,3 +35,4 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ${{ steps.coverage.outputs.report }}
+        yml: .github/configs/codecov.yml

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,34 @@
+name: coverage
+on:
+  pull_request:
+    paths:
+    - '**.rs'
+    - '**/Cargo.toml'
+    - '**/Cargo.lock'
+    - .github/workflows/coverage.yml
+  push:
+    branches:
+    - master
+jobs:
+  codecov:
+    name: codecov
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
+    - uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --workspace --no-fail-fast
+      env:
+        CARGO_INCREMENTAL: '0'
+        RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads'
+    - id: coverage
+      uses: actions-rs/grcov@v0.1
+    - uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ${{ steps.coverage.outputs.report }}


### PR DESCRIPTION
This adds code coverage reporting using the _grcov_ tool and uploads results to _codecov.io_.