### PR TITLE
Add code coverage via tarpaulin on codecov

### DIFF
--- a/.github/configs/codecov.yml
+++ b/.github/configs/codecov.yml
@@ -1,1 +1,0 @@
-comment: false

--- a/.github/configs/codecov.yml
+++ b/.github/configs/codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,6 +19,27 @@ jobs:
       with:
         toolchain: stable
         override: true
+    - uses: actions-rs/cargo@v1
+      with:
+        command: generate-lockfile
+    - uses: actions/cache@v1
+      with:
+        path: ~/.cargo/registry
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-registry-
+    - uses: actions/cache@v1
+      with:
+        path: ~/.cargo/git
+        key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-git-
+    - uses: actions/cache@v1
+      with:
+        path: target/debug
+        key: ${{ runner.os }}-target-tarpaulin-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-target-tarpaulin-
     - uses: actions-rs/tarpaulin@v0.1
       with:
         version: latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         toolchain: stable
         override: true
-    - uses: garyttierney/tarpaulin@f75a8fbd9e5128742c8ca1f98cd23ab7ca173f07
+    - uses: actions-rs/tarpaulin@v0.1
       with:
         version: latest
     - uses: codecov/codecov-action@v1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,32 @@
+name: coverage
+on:
+  pull_request:
+    paths:
+    - '**.rs'
+    - '**/Cargo.toml'
+    - '**/Cargo.lock'
+    - .github/workflows/coverage.yml
+  push:
+    branches:
+    - master
+jobs:
+  tarpaulin:
+    name: tarpaulin
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - uses: garyttierney/tarpaulin@f75a8fbd9e5128742c8ca1f98cd23ab7ca173f07
+      with:
+        version: latest
+    - uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        yml: .github/configs/codecov.yml
+    - uses: actions/upload-artifact@v1
+      with:
+        name: code-coverage-report
+        path: cobertura.xml

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,6 @@ jobs:
     - uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        yml: .github/configs/codecov.yml
     - uses: actions/upload-artifact@v1
       with:
         name: code-coverage-report


### PR DESCRIPTION
This is an alternative method of adding code coverage utilising _tarpaulin_ instead of _grcov_. Results are also uploaded to _codecov.io_.