### PR TITLE
Disable label actions on repository forks

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -4,6 +4,7 @@ jobs:
   pr:
     name: pr
     runs-on: ubuntu-latest
+    if: github.repository == 'brace-rs/project-template'
     steps:
     - if: github.event_name == 'pull_request' && github.event.action == 'opened'
       uses: TimonVS/pr-labeler-action@v3


### PR DESCRIPTION
This disables the label actions on repository forks due to the lack of write access which would cause workflows to fail.