### PR TITLE
Clean continuous integration caches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,3 +45,6 @@ jobs:
       with:
         command: build
         args: --workspace --release
+    - run: |
+        cargo install cargo-cache --no-default-features --features ci-autoclean
+        cargo-cache

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -50,3 +50,6 @@ jobs:
       with:
         name: code-coverage-report
         path: cobertura.xml
+    - run: |
+        cargo install cargo-cache --no-default-features --features ci-autoclean
+        cargo-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,3 +45,6 @@ jobs:
       with:
         command: test
         args: --workspace
+    - run: |
+        cargo install cargo-cache --no-default-features --features ci-autoclean
+        cargo-cache


### PR DESCRIPTION
This reduces the size of the continuous integration caches by using the _cargo-clean_ utility.