### PR TITLE
Add clippy check name

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,4 +37,5 @@ jobs:
     - uses: actions-rs/clippy-check@v1
       with:
         args: --all -- -D warnings
+        name: clippy-results
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds a name to the *clippy-check* action.

Currently whenever the *clippy* results are published they are added to an unnamed workflow under the name *clippy*.  Ideally it should be visible under the workflow that triggered the checks. This may be a problem with the action or a limitation of using the action with pull requests. However it may instead be a problem with the conflicting name being used for both the job and the results upload.