### PR TITLE
Rename clippy lint results check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,6 +30,7 @@ jobs:
       uses: actions-rs/clippy-check@v1
       with:
         args: --all -- -D warnings
+        name: Lint / Results
         token: ${{ secrets.GITHUB_TOKEN }}
 
   build:


### PR DESCRIPTION
This renames the clippy lint results check from the default value.