### PR TITLE
Set code coverage to informational only

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,14 @@
+coverage:
+  precision: 2
+  round: down
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
 ignore:
 - "**/tests"
 - "**/benches"


### PR DESCRIPTION
This updates the code coverage to be informational only to not fail workflows on coverage misses.