### PR TITLE
Ignore tests in code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,7 @@ jobs:
       uses: actions-rs/tarpaulin@v0.1
       with:
         version: latest
+        args: --ignore-tests
 
     - name: Upload code coverage
       uses: codecov/codecov-action@v1

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -1,7 +1,13 @@
+pub fn add_two(a: i32) -> i32 {
+    a + 2
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
+    fn it_adds_two() {
+        assert_eq!(add_two(2), 4);
     }
 }


### PR DESCRIPTION
This disables the code coverage of tests to ensure that only production code is analysed.