### PR TITLE
Remove clippy configuration

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,0 @@
-cognitive-complexity-threshold = 25


### PR DESCRIPTION
This removes the `clippy` configuration file that sets the same value for `cognitive-complexity-threshold` as the default in an effort to slim down the template.