### PR TITLE
Use workspace members wildcard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
 [workspace]
 members = [
-  "crates/project",
+  "crates/*",
 ]


### PR DESCRIPTION
This updates the workspace members to use a wildcard instead of a fixed name.