### PR TITLE
Update badges on crate README

### DIFF
--- a/crates/project-template/README.md
+++ b/crates/project-template/README.md
@@ -1,14 +1,17 @@
 # project-template
 
+[![Crates Status][crates-badge]][crates-badge-url]
+[![Docs Status][docs-badge]][docs-badge-url]
 [![Build Status][build-badge]][build-badge-url]
-[![Coverage Status][coverage-badge]][coverage-badge-url]
 [![License][license-badge]][license-badge-url]
 
 A project template for the quick instantiation of rust projects.
 
+[crates-badge]: https://img.shields.io/crates/v/project-template
+[crates-badge-url]: https://crates.io/crates/project-template
+[docs-badge]: https://img.shields.io/docsrs/project-template
+[docs-badge-url]: https://docs.rs/project-template
 [build-badge]: https://img.shields.io/github/workflow/status/brace-rs/project-template/CI/main
 [build-badge-url]: https://github.com/brace-rs/project-template/actions?query=workflow%3ACI
-[coverage-badge]: https://img.shields.io/codecov/c/github/brace-rs/project-template/main
-[coverage-badge-url]: https://codecov.io/gh/brace-rs/project-template
 [license-badge]: https://img.shields.io/badge/license-MIT%20OR%20Apache%202.0-blue.svg
 [license-badge-url]: https://github.com/brace-rs/project-template#license


### PR DESCRIPTION
This updates the badges on the crate README to remove the coverage that applies to the entire repository and adds links to crates.io and docs.rs.