### PR TITLE
Decrement package version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "project-template"
-version = "0.1.0"
+version = "0.0.0"

--- a/packages/project-template/Cargo.toml
+++ b/packages/project-template/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "project-template"
-version = "0.1.0"
+version = "0.0.0"
 description = "A project template for the quick instantiation of rust projects."
 authors = ["Daniel Balcomb <daniel.balcomb@gmail.com>"]
 keywords = []


### PR DESCRIPTION
This decrements the package version, resetting it to `0.0.0`. This will support a future bump-based release workflow that can bump the minor version to `0.1.0` instead of skipping straight to `0.2.0`.