### PR TITLE
Update codecov ignore paths

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,6 +10,6 @@ coverage:
         informational: true
 
 ignore:
-- "**/tests"
-- "**/benches"
-- "**/examples"
+- tests
+- benches
+- examples


### PR DESCRIPTION
This updates the codecov ignore paths to only include top-level directories.